### PR TITLE
Add rc 3.13 to testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13.0rc3"]
         django-version: ["5.0", "5.1"]
 
     steps:


### PR DESCRIPTION
We need to use the release candidate because https://github.com/indygreg/python-build-standalone hasn't quite released 3.13.0 (though they have been trying!)

Fixes #16 